### PR TITLE
[back-merge] ARACHNE-2485. Case insensitive search of users

### DIFF
--- a/src/main/java/com/odysseusinc/arachne/portal/repository/UserSpecifications.java
+++ b/src/main/java/com/odysseusinc/arachne/portal/repository/UserSpecifications.java
@@ -49,7 +49,7 @@ public class UserSpecifications {
 
     public static <U extends IUser> Specification<U> withFieldLike(String field, String namePattern) {
 
-        return (root, query, cb) -> cb.like(root.get(field), namePattern);
+        return (root, query, cb) -> cb.like(cb.lower(root.get(field)), namePattern);
     }
 
     public static <U extends IUser> Specification<U> usersIn(final Set<Long> tenantIds) {

--- a/src/main/java/com/odysseusinc/arachne/portal/service/impl/BaseUserServiceImpl.java
+++ b/src/main/java/com/odysseusinc/arachne/portal/service/impl/BaseUserServiceImpl.java
@@ -714,7 +714,7 @@ public abstract class BaseUserServiceImpl<
             spec = spec.and(userEnabled());
         }
         if (!StringUtils.isEmpty(userSearch.getQuery())) {
-            String pattern = userSearch.getQuery() + "%";
+            String pattern = "%" + userSearch.getQuery().toLowerCase() + "%";
             spec = spec.and(withNameOrEmailLike(pattern));
         }
 


### PR DESCRIPTION
changed search pattern - now searched string can match not only the start part of word
search ignores case