### PR TITLE
Always create (or autolink if eligible) missing user accounts on external login

### DIFF
--- a/src/main/java/com/odysseusinc/arachne/portal/security/Oauth2SuccessHandler.java
+++ b/src/main/java/com/odysseusinc/arachne/portal/security/Oauth2SuccessHandler.java
@@ -112,7 +112,7 @@ public class Oauth2SuccessHandler extends SavedRequestAwareAuthenticationSuccess
         log.info("User [{}] not found in DB, creating...", username);
         User user = new User();
         user.setUsername(username);
-        user.setEmail(email);
+        user.setEmail(username);
         user.setEnabled(enabledByDefault);
         user.setContactEmail(email);
         // Elixir currently gives nothing under StandardClaimNames.EMAIL_VERIFIED


### PR DESCRIPTION
Ensures that if autolink=false, user can be created when logged in via external provider, without provoking unique email constaint violation